### PR TITLE
Add unrestricted sheet functionality, source column, and refactor code to make updates easier

### DIFF
--- a/scripts/mobilize_sync.py
+++ b/scripts/mobilize_sync.py
@@ -99,6 +99,27 @@ hq_columns = {
                 'data_entry_data': 13
 }
 
+
+hq_column_letters = {
+                'date_joined': 'F',
+                'first_name': 'A',
+                'last_name': 'B',
+                'email': 'C',
+                'phone': 'D',
+                'total_signups': 'G',
+                'total_attendances': 'H',
+                'first_signup': 'I',
+                'first_attendance': 'J',
+                'days_since_last_signup': 'K',
+                'days_since_last_attendance': 'L',
+                'status': 'E',
+                'zipcode': 'O',
+                'birthyear': 'P',
+                'source': 'Q',
+                'interest_form_responses': 'M',
+                'data_entry_data': 'N'
+}
+
 # Store as list too
 hq_columns_list = ['first_name',
                     'last_name',
@@ -334,7 +355,8 @@ def mobilize_updates(mobilize_dict: dict, hq: list, hq_worksheet, hq_columns: di
             event_attendance_updates.append([status] + hq_row[hq_columns['date_joined']:
                                                               hq_columns['interest_form_responses']])
     # Send the updates to Hub HQ
-    hq_worksheet.update('E4:L', event_attendance_updates)
+    range = hq_column_letters['status'] + '4:' + hq_column_letters['days_since_last_attendance']
+    hq_worksheet.update(range, event_attendance_updates)
 
     # Now we convert the remaining Mobilize records, for which no matches were found, and reformat them to a parson's
     # table so that we can append them to the google sheet using the parson's google sheet append method. We also add a

--- a/scripts/mobilize_sync.py
+++ b/scripts/mobilize_sync.py
@@ -91,11 +91,14 @@ hq_columns = {
                 'first_attendance': 9,
                 'days_since_last_signup': 10,
                 'days_since_last_attendance': 11,
-                'status':4,
-                'zipcode':14,
-                'interest_form_responses':12,
-                'data_entry_data':13
+                'status': 4,
+                'zipcode': 14,
+                'birthyear': 15,
+                'source': 16,
+                'interest_form_responses': 12,
+                'data_entry_data': 13
 }
+
 # Store as list too
 hq_columns_list = ['first_name',
                     'last_name',
@@ -111,7 +114,10 @@ hq_columns_list = ['first_name',
                     'days_since_last_attendance',
                     'interest_form_responses',
                     'data_entry_data',
-                    'zipcode']
+                    'zipcode',
+                    'birthyear',
+                    'source']
+
 # Get 'scheduled' spreadsheet
 hubs = parsons_sheets.get_worksheet('1ESXwSfjkDrgCRYrAag_SHiKCMIgcd1U3kz47KLNpGeA', 'scheduled')
 # Create errors list of lists to populate and push to redshift at the end

--- a/scripts/setup_script.py
+++ b/scripts/setup_script.py
@@ -305,12 +305,12 @@ def main():
 
         # Now protect ranges so that hubs don't mess up the sync editing those ranges
         protect_range(hub, 'Interest Form','A:Y')
-        protect_range(hub, 'Data Entry', 'B1:F2')
+        protect_range(hub, 'Data Entry', 'A1:G2')
         protect_range(hub, 'Hub HQ', 'A:O')
         protect_range(hub, 'Analytics Dashboard', 'A:Y')
-        protect_range(hub, 'Explainer Docs', 'A:O')
-        protect_range(hub, 'National List Signups', 'A:H')
+        protect_range(hub, 'Explainer Docs', 'A:Q')
         protect_range(hub, 'HQ Settings', 'A1:F3')
+        protect_range(hub, 'Unrestricted', 'A1:I')
 
 
     succeeded_hubs = hubs.select_rows(lambda row: row.hub_name not in errored_hub_list)

--- a/scripts/sheets_sync.py
+++ b/scripts/sheets_sync.py
@@ -118,7 +118,7 @@ hq_column_letters = {
                 'source': 'Q',
                 'interest_form_responses': 'M',
                 'data_entry_data': 'N',
-                'date_claimed':'R'
+                'date_claimed': 'R'
 }
 
 unrestricted_column_letters = {

--- a/scripts/sheets_sync.py
+++ b/scripts/sheets_sync.py
@@ -322,7 +322,7 @@ def hq_updates(sheet_dict: dict, hq, sheet: str, hq_worksheet, unrestricted_shee
     hq_append_tbl = Table([hq_columns_list])
     hq_append_tbl.concat(sheet_dict_table)
     hq_append_tbl.fillna_column('status','HOT LEAD')
-    hq_append_tbl.move_column('status',4)
+    hq_append_tbl.move_column('status',hq_columns['status'])
     if sheet == 'form responses':
         hq_append_tbl.fillna_column('source', 'Interest Form')
     if sheet == 'data entry sheet':

--- a/scripts/sheets_sync.py
+++ b/scripts/sheets_sync.py
@@ -396,7 +396,9 @@ def main():
             parsons_sheets.append_to_sheet(hub['spreadsheet_id'], signup_form_table, 'Hub HQ')
             parsons_sheets.append_to_sheet(hub['spreadsheet_id'], unrestict_append1_tbl, 'Unrestricted')
         except ValueError:
-            logger.info(f'''No new signup form contacts for {hub['hub_name']}''')
+            logger.info(f'''No new data entries for {hub['hub_name']}''')
+        except Exception as e:
+            log_error(e, 'sheets_sync', 'Error adding new Interest Form contacts', hq_errors, hub)
         # Repeat process for data entry sheet
         # Get Hub HQ table, which now has new form respondants
         hq = hq_worksheet.get_all_values()
@@ -417,6 +419,8 @@ def main():
             parsons_sheets.append_to_sheet(hub['spreadsheet_id'], unrestict_append2_tbl, 'Unrestricted')
         except ValueError:
             logger.info(f'''No new data entries for {hub['hub_name']}''')
+        except Exception as e:
+            log_error(e, 'sheets_sync', 'Error adding new Data Entry Sheet contacts', hq_errors, hub)
         # Send errors table to redshift
     if len(hq_errors) > 1:
         rs.copy(Table(hq_errors), 'sunrise.hub_hq_errors', if_exists='append', distkey='hub',

--- a/scripts/sheets_sync.py
+++ b/scripts/sheets_sync.py
@@ -322,6 +322,7 @@ def hq_updates(sheet_dict: dict, hq, sheet: str, hq_worksheet, unrestricted_shee
             sheet_dict[hq_email]
             responses = [sheet_dict[hq_email][concat_col_idx]]
             updates.append(responses)
+            # If contact originated from ntl, added a claimed by hub date
             mark_as_claimed(hq_row, idx, hq_worksheet)
             del sheet_dict[hq_email]
         # When no match is found, create a list/row with empty values

--- a/scripts/sheets_sync.py
+++ b/scripts/sheets_sync.py
@@ -99,6 +99,32 @@ hq_columns = {
                 'data_entry_data': 13
 }
 
+hq_column_letters = {
+                'date_joined': 'F',
+                'first_name': 'A',
+                'last_name': 'B',
+                'email': 'C',
+                'phone': 'D',
+                'total_signups': 'G',
+                'total_attendances': 'H',
+                'first_signup': 'I',
+                'first_attendance': 'J',
+                'days_since_last_signup': 'K',
+                'days_since_last_attendance': 'L',
+                'status': 'E',
+                'zipcode': 'O',
+                'birthyear': 'P',
+                'source': 'Q',
+                'interest_form_responses': 'M',
+                'data_entry_data': 'N'
+}
+
+unrestricted_column_letters = {
+                    'interest_form_responses': 'F',
+                    'data_entry_data': 'G'
+                    }
+
+
 signup_columns = {
     'date_joined': 0,
     'first_name': 1,
@@ -286,17 +312,23 @@ def hq_updates(sheet_dict: dict, hq, sheet: str, hq_worksheet, unrestricted_shee
     if sheet == 'form responses':
         try:
             # Update concatenated form response column in hq sheet
-            hq_worksheet.update('M4:M', updates)
+            range1 = hq_column_letters['interest_form_responses'] + '4:' + hq_column_letters['interest_form_responses']
+            hq_worksheet.update(range1, updates)
             # Update in unrestricted sheet
-            unrestricted_sheet.update('F4:F', updates)
+            range2 = (unrestricted_column_letters['interest_form_responses'] + '4:' +
+                    unrestricted_column_letters['interest_form_responses'])
+            unrestricted_sheet.update(range2, updates)
         except HttpError as e:
             log_error(e, 'sheets_sync', 'Error while updating form response column', hq_errors, hub)
     elif sheet == 'data entry sheet':
         try:
             # Update concatenated data entry field for existing records in hq sheet
-            hq_worksheet.update('N4:N', updates)
+            range3 = hq_column_letters['data_entry_data'] + '4:' + hq_column_letters['data_entry_data']
+            hq_worksheet.update(range3, updates)
             # Update in unrestricted sheet
-            unrestricted_sheet.update('G4:G', updates)
+            range4 = (unrestricted_column_letters['data_entry_data'] + '4:' +
+                      unrestricted_column_letters['data_entry_data'])
+            unrestricted_sheet.update(range4, updates)
         except HttpError as e:
             log_error(e, 'sheets_sync', 'Error while updating data entry data column', hq_errors, hub)
 


### PR DESCRIPTION
This pull request has 5 main components:

1. Refactor the code that prepared new contacts from the _interest form sheet_ and _data entry sheet_ to be appended to the _Hub HQ sheet_
2. Refactor the code that updates event attendance data, status, and the concatenated data fields
3. Added a source column and assign values for new contacts being synced from the _interest form sheet_ and _data entry sheet_ to be appended to Hub HQ
4. Establish a sync/transfer of data from the _interest form sheet_ and _data entry sheet_ to be appended to the _Unrestricted sheet_, which will be a data set hubs can use for lobbying and electoral work. 
5. Add a function for indicating when a national contact has been "claimed" by a hub (i.e. when a contact that originally arrived in HQ from the national database has signed up for one of the hub's mobilize events, filled out their interest form, or entered into the data entry sheet). The EveryAction sync does not subscribe people from hq to the hub's everyaction email list who originally arrived via the national database unless they've been marked as 'claimed.'

**Refactor the code that prepared new contacts from the _interest form sheet_ and _data entry sheet_ to be appended to the _Hub HQ sheet_**
_LINES 270 - 340 OF SHEET_SYNC.PY_
As Hub HQ evolves, columns might be rearranged. If the code isn't structured correctly, rearranging columns in Hub HQ would require updating the code base in lots of different places. The changes made here remove one of those problematic areas by using parsons table methods that deal with columns by name instead of index.

**Refactor the code that updates event attendance data, status, and the concatenated data fields**
_LINES 103-120  & 326-327 OF SHEET_SYNC.PY AND LINES 103-120 & 358-359 OF MOBILIZE SYNC_
Mitigates the same possibility of columns moving by:
1. creating a reference dictionary (column name: column_index_letter) at the top of the scripts that can be updated if columns change position
2. calling that dictionary later in the script when making api calls to update ranges involving those columns (as opposed to having those ranges stated plainly). Instead of saying `sheet.update[A1]` we instead do `sheet.update(reference_dict['column_name'] + '1')`

**Added a source column and assign values for new contacts being synced from the _interest form sheet_ and _data entry sheet_ to be appended to Hub HQ**
_LINES 358-362 OF SHEET_SYNC.PY_
I'm adding a source column because contacts from the national EveryAction database will now be synced into HQ and shouldn't be synced/subscribed to the hub's everyaction committee. By adding a source column, I can subset the table of contacts that is subscribe to EveryAction to exclude people with the source 'National List.' Note that I cannot incorporate source column functionality in the other scripts because I still don't have permissions to access Sunrise's tables, but I have it on my to-do list! 

**Establish a sync/transfer of data from the _interest form sheet_ and _data entry sheet_ to be appended to the _Unrestricted sheet_, which will be a data set hubs can use for lobbying and electoral work.** 
_LINES 314-331,364-366,380,392 AND 412 OF SHEETS_SYNC_
This was very easy! I just replicated the lines of code that updated data in HQ and appended data to HQ, then pointed those lines of code at the new Unrestricted sheet. It runs without issue!

**Add a method for indicating when a national contact has been "claimed" by a hub**
This happens via the mark_as_claimed function, which is called in the update_hq function. If a contact in the Interest Form Responses sheet or Data Entry Sheet has a value of 'National Email List' in the Hub HQ `source` column and no value in `date_claimed` column, then today's date is added for that contacts in the `date_claimed` column. The everyaction_sync.py will then detect that change and subscribe them to EveryAction. 

**Other random things**
- Made small updates to redshift sync to account for newly added columns
- I broke birthyear into it's own column so that when we sync in contacts from the national database we can put birthyear data in a column with brithyear data the hub might have collected
- I can't move anything else forward without getting permissions on those tables :(