### PR TITLE
Rework mobilize_sync.py and setup_script

### DIFF
--- a/scripts/mobilize_sync.py
+++ b/scripts/mobilize_sync.py
@@ -99,6 +99,27 @@ hq_columns = {
                 'data_entry_data': 13
 }
 
+
+hq_column_letters = {
+                'date_joined': 'F',
+                'first_name': 'A',
+                'last_name': 'B',
+                'email': 'C',
+                'phone': 'D',
+                'total_signups': 'G',
+                'total_attendances': 'H',
+                'first_signup': 'I',
+                'first_attendance': 'J',
+                'days_since_last_signup': 'K',
+                'days_since_last_attendance': 'L',
+                'status': 'E',
+                'zipcode': 'O',
+                'birthyear': 'P',
+                'source': 'Q',
+                'interest_form_responses': 'M',
+                'data_entry_data': 'N'
+}
+
 # Store as list too
 hq_columns_list = ['first_name',
                     'last_name',
@@ -334,7 +355,8 @@ def mobilize_updates(mobilize_dict: dict, hq: list, hq_worksheet, hq_columns: di
             event_attendance_updates.append([status] + hq_row[hq_columns['date_joined']:
                                                               hq_columns['interest_form_responses']])
     # Send the updates to Hub HQ
-    hq_worksheet.update('E4:L', event_attendance_updates)
+    range = hq_column_letters['status'] + '4:' + hq_column_letters['days_since_last_attendance']
+    hq_worksheet.update(range, event_attendance_updates)
 
     # Now we convert the remaining Mobilize records, for which no matches were found, and reformat them to a parson's
     # table so that we can append them to the google sheet using the parson's google sheet append method. We also add a

--- a/scripts/mobilize_sync.py
+++ b/scripts/mobilize_sync.py
@@ -91,11 +91,14 @@ hq_columns = {
                 'first_attendance': 9,
                 'days_since_last_signup': 10,
                 'days_since_last_attendance': 11,
-                'status':4,
-                'zipcode':14,
-                'interest_form_responses':12,
-                'data_entry_data':13
+                'status': 4,
+                'zipcode': 14,
+                'birthyear': 15,
+                'source': 16,
+                'interest_form_responses': 12,
+                'data_entry_data': 13
 }
+
 # Store as list too
 hq_columns_list = ['first_name',
                     'last_name',
@@ -111,7 +114,10 @@ hq_columns_list = ['first_name',
                     'days_since_last_attendance',
                     'interest_form_responses',
                     'data_entry_data',
-                    'zipcode']
+                    'zipcode',
+                    'birthyear',
+                    'source']
+
 # Get 'scheduled' spreadsheet
 hubs = parsons_sheets.get_worksheet('1ESXwSfjkDrgCRYrAag_SHiKCMIgcd1U3kz47KLNpGeA', 'scheduled')
 # Create errors list of lists to populate and push to redshift at the end

--- a/scripts/setup_script.py
+++ b/scripts/setup_script.py
@@ -260,7 +260,7 @@ final_base as (
       , contacts.last as last_name
       , email.email
       , phone.phone
-      , TO_CHAR(CONVERT_TIMEZONE('EST','UTC', zip.datemodified), 'YYYY-MM-DD hh24:MI:SS') as date_joined
+      , TO_CHAR(CONVERT_TIMEZONE('EST','UTC', zip.datemodified), 'MM/DD/YYYY HH24:MI:SS') as date_joined
       , contacts.birthyear
       -- need to dedup by email
       , row_number() over(partition by email.email order by zip.datemodified desc) = 1 as is_most_recent

--- a/scripts/setup_script.py
+++ b/scripts/setup_script.py
@@ -431,7 +431,7 @@ def main():
         # Now protect ranges so that hubs don't mess up the sync editing those ranges
         protect_range(hub, 'Interest Form','A:Y')
         protect_range(hub, 'Data Entry', 'A1:G2')
-        protect_range(hub, 'Hub HQ', 'A:O')
+        protect_range(hub, 'Hub HQ', 'A:R')
         protect_range(hub, 'Analytics Dashboard', 'A:Y')
         protect_range(hub, 'Explainer Docs', 'A:Q')
         protect_range(hub, 'HQ Settings', 'A1:F3')

--- a/scripts/setup_script.py
+++ b/scripts/setup_script.py
@@ -1,12 +1,14 @@
 #Civis container script: https://platform.civisanalytics.com/spa/#/scripts/containers/112448113
 
-# This script "sets up" Hub HQs by dumping all the contacts from the national EveryAction that are in the hub's area
-# (based on a zipcode radius search) into the the 'National List Signups.' It does so by looping through each hub
-# in the 'set up' tabl of the Hub HQ Set Up Sheet
+# This script "sets up" Hub HQs by adding all the contacts from the national EveryAction that are in the hub's area
+# (based on a zipcode radius search) and all of the contacts who have signed up for any of the hubs mobilize events
+# into the the ''Hub HQ' sheet. It does so by looping through each hub in the 'set up' table of the Hub HQ Set Up Sheet
 # (https://docs.google.com/spreadsheets/d/1ESXwSfjkDrgCRYrAag_SHiKCMIgcd1U3kz47KLNpGeA/edit#gid=0) and for each hub:
-# 1) using the zipcode and zipcode radius provided to find all the zipcodes in the radius
+# 1) Using the zipcode and zipcode radius provided to find all the zipcodes in the radius
 # 2) Sending a query to Redshift to get all contacts that live in those zipcodes
-# 3) Appending that list of contacts to the 'National List Signups' sheet
+# 3) Querying Redshift for all of the hub's mobilize contacts
+# 4) Compiling the two tables
+# 5) Appending that table of all contacts to the hub's 'Hub HQ' sheet
 # If the script succeeds for a hub, that hub's info is transferred from the 'set up' tab to the 'scheduled' tab.
 # If the script fails for a hub, the hub remains in the 'set up' tab and the traceback error is logged in the 'errors'
 # tab of the same spreadsheet

--- a/scripts/sheets_sync.py
+++ b/scripts/sheets_sync.py
@@ -322,7 +322,7 @@ def hq_updates(sheet_dict: dict, hq, sheet: str, hq_worksheet, unrestricted_shee
     hq_append_tbl = Table([hq_columns_list])
     hq_append_tbl.concat(sheet_dict_table)
     hq_append_tbl.fillna_column('status','HOT LEAD')
-    hq_append_tbl.move_column('status',4)
+    hq_append_tbl.move_column('status',hq_columns['status'])
     if sheet == 'form responses':
         hq_append_tbl.fillna_column('source', 'Interest Form')
     if sheet == 'data entry sheet':

--- a/scripts/sheets_sync.py
+++ b/scripts/sheets_sync.py
@@ -99,6 +99,32 @@ hq_columns = {
                 'data_entry_data': 13
 }
 
+hq_column_letters = {
+                'date_joined': 'F',
+                'first_name': 'A',
+                'last_name': 'B',
+                'email': 'C',
+                'phone': 'D',
+                'total_signups': 'G',
+                'total_attendances': 'H',
+                'first_signup': 'I',
+                'first_attendance': 'J',
+                'days_since_last_signup': 'K',
+                'days_since_last_attendance': 'L',
+                'status': 'E',
+                'zipcode': 'O',
+                'birthyear': 'P',
+                'source': 'Q',
+                'interest_form_responses': 'M',
+                'data_entry_data': 'N'
+}
+
+unrestricted_column_letters = {
+                    'interest_form_responses': 'F',
+                    'data_entry_data': 'G'
+                    }
+
+
 signup_columns = {
     'date_joined': 0,
     'first_name': 1,
@@ -286,17 +312,23 @@ def hq_updates(sheet_dict: dict, hq, sheet: str, hq_worksheet, unrestricted_shee
     if sheet == 'form responses':
         try:
             # Update concatenated form response column in hq sheet
-            hq_worksheet.update('M4:M', updates)
+            range1 = hq_column_letters['interest_form_responses'] + '4:' + hq_column_letters['interest_form_responses']
+            hq_worksheet.update(range1, updates)
             # Update in unrestricted sheet
-            unrestricted_sheet.update('F4:F', updates)
+            range2 = (unrestricted_column_letters['interest_form_responses'] + '4:' +
+                    unrestricted_column_letters['interest_form_responses'])
+            unrestricted_sheet.update(range2, updates)
         except HttpError as e:
             log_error(e, 'sheets_sync', 'Error while updating form response column', hq_errors, hub)
     elif sheet == 'data entry sheet':
         try:
             # Update concatenated data entry field for existing records in hq sheet
-            hq_worksheet.update('N4:N', updates)
+            range3 = hq_column_letters['data_entry_data'] + '4:' + hq_column_letters['data_entry_data']
+            hq_worksheet.update(range3, updates)
             # Update in unrestricted sheet
-            unrestricted_sheet.update('G4:G', updates)
+            range4 = (unrestricted_column_letters['data_entry_data'] + '4:' +
+                      unrestricted_column_letters['data_entry_data'])
+            unrestricted_sheet.update(range4, updates)
         except HttpError as e:
             log_error(e, 'sheets_sync', 'Error while updating data entry data column', hq_errors, hub)
 


### PR DESCRIPTION
The updates to focus on for this pull request are the updates in the Mobilize sync script and the Setup script. Changes to the other scripts were pulled into this branch via merge (I should have rebased instead) and are explained in the update-sheets-sync branch/pull request. 

**Mobilize Sync Updates**
- _Rework the code that constructs the table of new mobilize contacts that is appended to the bottom of hub hq._ Previously, if the order of columns in hub hq had changed, the code in the script would have needed to be updated in two places. Now it only needs to be updated in one place -- the global variables at the top. 
- _Add a source column to the table of new mobilize contacts._ Not only will the source column allow hubs to know the origin of their supporters/members, but it also will prevent any contacts from the national list from being subscribed to the hub's email list. 
- Add a function for indicating when a national contact has been "claimed" by a hub (i.e. when a contact that originally arrived in HQ from the national database has signed up for one of the hub's mobilize events, filled out their interest form, or entered into the data entry sheet). The EveryAction sync does not subscribe people from hq to the hub's everyaction email list who originally arrived via the national database unless they've been marked as 'claimed.' This happens via the mark_as_claimed function, which is called in the update_hq function. If a contact in the Interest Form Responses sheet or Data Entry Sheet has a value of 'National Email List' in the Hub HQ `source` column and no value in `date_claimed` column, then today's date is added for that contacts in the `date_claimed` column. The everyaction_sync.py will then detect that change and subscribe them to EveryAction. 


**Set Up Script Updates**
Previously, the set up script retrieved contacts from the national database and put them into the 'National List' sheet. But now that the national contacts will share a sheet with mobilize contacts, the script was updated to put both mobilize and national contacts into the hub hq sheet so that when a hub starts using Hub HQ it's already filled with data.  